### PR TITLE
A source counts what it contributed, not what it read

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -327,6 +327,11 @@ export interface SourceStatus {
   trust: string;
   license?: string;
   sha?: string;
+  /**
+   * How many of this source's entries reached the index — counted *after*
+   * cross-source dedupe, so it is what filtering on this source yields rather
+   * than what the sync read.
+   */
   count: number;
   ok: boolean;
   error?: string;
@@ -378,10 +383,10 @@ export interface LibraryBrowse {
   /**
    * Per source, how many entries are *actually indexed*.
    *
-   * Not `SourceStatus.count`, which is taken before entries are deduplicated
-   * across sources and so overstates any source that lost a name to one listed
-   * before it — measured at 204 against 180 for `wshobson-agents`. Browsing is
-   * the first place in the app that shows a per-source number, and offering a
+   * Counted from the index rather than read from `SourceStatus.count`. The two
+   * agree since the count began being taken after cross-source dedupe instead
+   * of before it — measured at 204 against 180 for `wshobson-agents` — but an
+   * index synced before that still carries the old number, and offering a
    * filter that promises 204 and yields 180 is worse than offering none.
    */
   indexed: { name: string; label: string; entries: number }[];

--- a/server/src/browse.ts
+++ b/server/src/browse.ts
@@ -86,9 +86,12 @@ export function categorise(
  * How many entries each source really contributes, counted from the index
  * itself.
  *
- * `SourceStatus.count` cannot answer this: it is recorded per source before
- * `dedupe` drops names already claimed by a source listed earlier, so it
- * overstates by whatever it lost — 204 against 180 on the real catalogue. A
+ * `SourceStatus.count` now agrees, being recomputed after `dedupe` rather than
+ * before it, where it overstated by every name a source lost to one listed
+ * earlier — 204 against 180 on the real catalogue. This still counts the
+ * entries, because an index synced before that fix carries the old number and
+ * a filter promising 204 rows while yielding 180 is worse than offering none.
+ * Counting the list the filter reads makes the two impossible to disagree. A
  * source that contributes nothing still appears, with zero, rather than
  * vanishing from a filter that is supposed to list what there is.
  */

--- a/server/src/library.test.ts
+++ b/server/src/library.test.ts
@@ -59,6 +59,25 @@ function fakeHttp(files: Record<string, string>, overrides: Record<string, numbe
   return { http, calls };
 }
 
+/** The same fake, with a separate tree per repository. */
+function multiRepoHttp(repos: Record<string, Record<string, string>>): Http {
+  return async (url) => {
+    const repo = Object.keys(repos).find((r) => url.includes(`/${r}/`));
+    if (!repo) return { ok: false, status: 404, text: async () => '' };
+    const files = repos[repo];
+    if (url.includes('/commits/')) {
+      return { ok: true, status: 200, text: async () => JSON.stringify({ sha: HEAD }) };
+    }
+    if (url.includes('/git/trees/')) {
+      const tree = Object.keys(files).map((p) => ({ path: p, type: 'blob' }));
+      return { ok: true, status: 200, text: async () => JSON.stringify({ tree }) };
+    }
+    const file = Object.keys(files).find((p) => url.endsWith(`/${HEAD}/${p}`));
+    if (file) return { ok: true, status: 200, text: async () => files[file] };
+    return { ok: false, status: 404, text: async () => '' };
+  };
+}
+
 describe('globToRegExp', () => {
   it('matches a file at any depth', () => {
     const rx = globToRegExp('**/SKILL.md');
@@ -123,6 +142,36 @@ describe('syncSources', () => {
       { 'https://api.github.com/repos/anthropics/skills/commits/main': 404 },
     );
     expect((await syncSources([SOURCE], http, 1)).sources[0].error).toMatch(/not found/);
+  });
+
+  /**
+   * A count taken before dedupe describes what the sync read, not what the
+   * catalogue holds: measured on the real index, `wshobson-agents` reported 204
+   * while 180 of its entries reached `entries`, and the four sources summed to
+   * 556 against 532. `truncated` never covered it — that is the per-source cap.
+   */
+  it('counts what a source contributed, not what it read', async () => {
+    const http = multiRepoHttp({
+      'first/repo': {
+        'pdf/SKILL.md': skill('pdf', 'Reads PDFs and extracts text'),
+        'xlsx/SKILL.md': skill('xlsx', 'Creates and edits spreadsheets'),
+      },
+      'second/repo': {
+        // The same `kind:name` as the source listed before it: dropped.
+        'pdf/SKILL.md': skill('pdf', 'Also reads PDFs'),
+        'docx/SKILL.md': skill('docx', 'Writes documents'),
+      },
+    });
+    const first: Source = { ...SOURCE, name: 'first', repo: 'first/repo' };
+    const second: Source = { ...SOURCE, name: 'second', repo: 'second/repo' };
+    const index = await syncSources([first, second], http, 1);
+
+    const survived = (name: string) => index.entries.filter((e) => e.source === name).length;
+    expect(survived('second')).toBe(1);
+    expect(index.sources[1].count).toBe(survived('second'));
+    expect(index.sources[0].count).toBe(survived('first'));
+    // The property that was false: source counts sum to the catalogue.
+    expect(index.sources.reduce((n, s) => n + s.count, 0)).toBe(index.entries.length);
   });
 
   it('sends the token only to the API, never to raw file hosts', async () => {

--- a/server/src/library.ts
+++ b/server/src/library.ts
@@ -172,6 +172,7 @@ async function syncSource(
     ).filter((entry): entry is CatalogEntry => entry !== null);
 
     return {
+      // Provisional: `syncSources` lowers the count to what survives dedupe.
       status: { ...base, sha, count: entries.length, ok: true, truncated: truncated || undefined },
       entries,
     };
@@ -200,10 +201,18 @@ export async function syncSources(
   token?: string,
 ): Promise<LibraryIndex> {
   const results = await inBatches(sources, 3, (source) => syncSource(source, http, token));
+  const entries = dedupe(results.flatMap((r) => r.entries));
+  // What a source contributed is what survived. Counted per source before
+  // `dedupe` ran, the number overstates by every name already claimed by a
+  // source listed earlier — 204 against 180 for `wshobson-agents` on the real
+  // catalogue, and 556 against 532 summed. `truncated` does not cover this: it
+  // reports the MAX_PER_SOURCE cap, which no source currently hits.
+  const kept = new Map<string, number>();
+  for (const entry of entries) kept.set(entry.source, (kept.get(entry.source) ?? 0) + 1);
   return {
     fetchedAt: now,
-    sources: results.map((r) => r.status),
-    entries: dedupe(results.flatMap((r) => r.entries)),
+    sources: results.map((r) => ({ ...r.status, count: kept.get(r.status.name) ?? 0 })),
+    entries,
   };
 }
 


### PR DESCRIPTION
`SourceStatus.count` overstated for any source that lost entries to dedupe.

`syncSource` recorded `count: entries.length` per source; `syncSources` then ran
`dedupe` across every source, dropping any `kind:name` already claimed by a
source listed earlier. The count was taken before the drop, so it described what
the sync *read* rather than what the catalogue *holds*.

Measured on the real index before the fix:

```
anthropic-skills      count   18 | in index   18
voltagent-subagents   count  154 | in index  154
wshobson-agents       count  204 | in index  180   <-- 24 lost to dedupe
wshobson-skills       count  180 | in index  180
sum of counts 556 | index.entries 532
```

`truncated` never covered this — it reports the `MAX_PER_SOURCE` cap, which no
source currently hits.

## The change

`syncSources` recomputes each source's count from the deduped entries. A failed
source still lands at 0, since it contributes nothing to tally. `syncSource`
keeps setting its own count — the object needs one either way — marked
provisional so nobody reads it as final. `truncated` is untouched: dedupe does
not affect the cap.

## What was left alone, and why

`browse.ts` keeps counting the index rather than reading `count`. The two agree
from the next sync onward, but an index synced before this carries the old
number, and counting the same list the filter reads makes the number and the
rows structurally incapable of disagreeing. The comments in `browse.ts` and on
`LibraryBrowse.indexed` asserted `count` *cannot* answer this; that claim is now
wrong even though the conclusion stands, so both are rewritten.

`RolesModal.tsx` uses `count` only in the truncation warning, where it now reads
better rather than worse: "showing the first 180" becomes literally the number
shown.

## Evidence

New test: two sources both publishing `skill:pdf`, asserting the later source's
`count` equals its surviving entries (1, not the 2 it read) and that the counts
now sum to `entries.length` — the property that was false. Mutation-proved after
committing: reverting just the `sources:` line fails it with `expected 2 to be
1`, while the other 28 tests in the file still pass.

Full suite green: 789 server + 66 web, typecheck clean.

The on-disk index has already been re-synced with this code — 180 == 180, sum
532 == 532, with 0 entries added or removed. Until this merges, a re-sync from
`main` would put 204 back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
