### PR TITLE
Every test cleanup off rmSync, with the lock proved before the fix

### DIFF
--- a/server/src/crew.test.ts
+++ b/server/src/crew.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -93,7 +94,10 @@ describe('memory archive', () => {
     dir = mkdtempSync(path.join(tmpdir(), 'agentlings-mem-'));
     memory = new MemoryStore(dir);
   });
-  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+  // rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+  afterEach(() =>
+    rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('moves lessons aside instead of destroying them', () => {
     memory.append('Bea', 'learned something');

--- a/server/src/deliveries.test.ts
+++ b/server/src/deliveries.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { Job } from '@agentlings/shared';
@@ -10,9 +11,10 @@ let root: string;
 beforeEach(() => {
   root = mkdtempSync(path.join(tmpdir(), 'deliveries-'));
 });
-afterEach(() => {
-  rmSync(root, { recursive: true, force: true });
-});
+// rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+afterEach(() =>
+  rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+);
 
 const dirFor = (jobId: string) => path.join(root, jobId);
 

--- a/server/src/executors/claude.test.ts
+++ b/server/src/executors/claude.test.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -201,7 +202,10 @@ describe('repoListing', () => {
   beforeEach(() => {
     root = mkdtempSync(path.join(tmpdir(), 'agentlings-listing-'));
   });
-  afterEach(() => rmSync(root, { recursive: true, force: true }));
+  // rmSync cannot outwait a Windows file lock — see ./carry.test.ts.
+  afterEach(() =>
+    rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('lists files, nested ones included, with repo-relative paths', () => {
     mkdirSync(path.join(root, 'src'), { recursive: true });
@@ -439,7 +443,9 @@ describe('closeOutEvidence', () => {
   beforeEach(() => {
     dir = mkdtempSync(path.join(tmpdir(), 'agentlings-closeout-'));
   });
-  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+  afterEach(() =>
+    rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('says nothing when the run left nothing behind', () => {
     expect(closeOutEvidence(dir)).toBeNull();

--- a/server/src/executors/routed.test.ts
+++ b/server/src/executors/routed.test.ts
@@ -1,5 +1,6 @@
 import { createServer, type Server } from 'node:http';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
@@ -105,9 +106,11 @@ describe('RoutedExecutor', () => {
     progress = [];
   });
 
-  afterEach(() => {
-    rmSync(path.dirname(levelDir), { recursive: true, force: true });
-    rmSync(sandboxDir, { recursive: true, force: true });
+  // rmSync cannot outwait a Windows file lock — see ./carry.test.ts.
+  afterEach(async () => {
+    const opts = { recursive: true, force: true, maxRetries: 10, retryDelay: 50 };
+    await rm(path.dirname(levelDir), opts).catch(() => {});
+    await rm(sandboxDir, opts).catch(() => {});
   });
 
   function build(

--- a/server/src/gitwork.test.ts
+++ b/server/src/gitwork.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -28,7 +29,11 @@ describe('gitwork', () => {
     git(origin, 'commit', '-q', '-m', 'init');
   });
 
-  afterEach(() => rmSync(root, { recursive: true, force: true }));
+  // Deletes a git repository on Windows: rmSync cannot outwait a lock held by
+  // something outside this process — see executors/carry.test.ts for the measurement.
+  afterEach(() =>
+    rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('clones, captures edits and new files, and applies the patch upstream', async () => {
     const repo = await cloneRepo(origin, sandbox);

--- a/server/src/ledger.test.ts
+++ b/server/src/ledger.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -181,7 +182,10 @@ describe('persistence', () => {
   beforeEach(() => {
     root = mkdtempSync(path.join(tmpdir(), 'agentlings-ledger-'));
   });
-  afterEach(() => rmSync(root, { recursive: true, force: true }));
+  // rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+  afterEach(() =>
+    rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('appends and reads back', () => {
     append(root, entry({ jobId: 'a' }));

--- a/server/src/levels.test.ts
+++ b/server/src/levels.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -33,7 +33,7 @@ describe('crew colours are on the palette', () => {
     }
   });
 
-  it('for the legacy crew the migration writes', () => {
+  it('for the legacy crew the migration writes', async () => {
     const root = mkdtempSync(path.join(tmpdir(), 'agentlings-legacy-'));
     try {
       // The migration only fires when there is a pre-level cave to move.
@@ -43,7 +43,10 @@ describe('crew colours are on the palette', () => {
       expect(crew).toHaveLength(4);
       for (const member of crew) expect(PALETTE.has(member.color)).toBe(true);
     } finally {
-      rmSync(root, { recursive: true, force: true });
+      // A throw here would replace the assertion above with a lock error.
+      await rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(
+        () => {},
+      );
     }
   });
 });

--- a/server/src/levels.test.ts
+++ b/server/src/levels.test.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -54,7 +55,10 @@ describe('levels', () => {
     root = mkdtempSync(path.join(tmpdir(), 'agentlings-lvl-'));
   });
 
-  afterEach(() => rmSync(root, { recursive: true, force: true }));
+  // rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+  afterEach(() =>
+    rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('creates a level with meta, a starting crew of two, and a unique slug', () => {
     const meta = createLevelFiles(root, { name: 'Home Chores', project: 'Household', theme: 'household' });

--- a/server/src/library.test.ts
+++ b/server/src/library.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -284,7 +285,10 @@ describe('install manifest', () => {
   beforeEach(() => {
     root = mkdtempSync(path.join(tmpdir(), 'agentlings-lib-'));
   });
-  afterEach(() => rmSync(root, { recursive: true, force: true }));
+  // rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+  afterEach(() =>
+    rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('is new before install and installed after', () => {
     const names = { roles: [], skills: [] as string[] };

--- a/server/src/memory.test.ts
+++ b/server/src/memory.test.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -13,7 +14,10 @@ beforeEach(() => {
   dir = path.join(root, 'memory'); // not created yet: the store must make its own
   memory = new MemoryStore(dir);
 });
-afterEach(() => rmSync(root, { recursive: true, force: true }));
+// rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+afterEach(() =>
+  rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+);
 
 describe('lessons', () => {
   it('has nothing to say about an agentling who has never been taught', () => {

--- a/server/src/outputs.test.ts
+++ b/server/src/outputs.test.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -18,9 +19,10 @@ let dir: string;
 beforeEach(() => {
   dir = mkdtempSync(path.join(tmpdir(), 'agentlings-outputs-'));
 });
-afterEach(() => {
-  rmSync(dir, { recursive: true, force: true });
-});
+// rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+afterEach(() =>
+  rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+);
 
 /** The first bytes of a real PDF, NUL included — the shape that used to break. */
 const PDF = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x00, 0x0a, 0xff, 0xfe]);

--- a/server/src/preview.test.ts
+++ b/server/src/preview.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -15,9 +16,10 @@ let dir: string;
 beforeEach(() => {
   dir = mkdtempSync(path.join(tmpdir(), 'agentlings-preview-'));
 });
-afterEach(() => {
-  rmSync(dir, { recursive: true, force: true });
-});
+// rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+afterEach(() =>
+  rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+);
 
 async function writeDocx(name: string, paragraphs: string[]): Promise<string> {
   const { Document, Packer, Paragraph } = await import('docx');

--- a/server/src/queue.test.ts
+++ b/server/src/queue.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -16,9 +17,10 @@ describe('JobQueue', () => {
     queue = new JobQueue(root);
   });
 
-  afterEach(() => {
-    rmSync(root, { recursive: true, force: true });
-  });
+  // rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+  afterEach(() =>
+    rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('runs a job through its lifecycle', async () => {
     const job = queue.add({ title: 'Test job', prompt: 'do the thing' });

--- a/server/src/quote.test.ts
+++ b/server/src/quote.test.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -82,9 +83,10 @@ describe('quoteFor_', () => {
     ctx = { sandboxRoot, registry, surfaceFor: () => [] };
   });
 
-  afterEach(() => {
-    rmSync(root, { recursive: true, force: true });
-  });
+  // rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+  afterEach(() =>
+    rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   const quote = (text: string, noRouter = false) =>
     quoteFor_(ctx, levelDir, text, undefined, 'worker', undefined, noRouter);

--- a/server/src/recipes.test.ts
+++ b/server/src/recipes.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -129,7 +130,10 @@ describe('persistence', () => {
   beforeEach(() => {
     dir = mkdtempSync(path.join(tmpdir(), 'agentlings-recipes-'));
   });
-  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+  // rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+  afterEach(() =>
+    rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('survives a round trip', () => {
     const recipes = rememberRecipe([], {

--- a/server/src/roles.test.ts
+++ b/server/src/roles.test.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -55,7 +56,10 @@ describe('RoleRegistry', () => {
     registry.load();
   });
 
-  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+  // rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+  afterEach(() =>
+    rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('installs a role and lists it', () => {
     const role = registry.install(SCOUT);
@@ -83,7 +87,9 @@ describe('skills and memory', () => {
     dir = mkdtempSync(path.join(tmpdir(), 'agentlings-skills-'));
   });
 
-  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+  afterEach(() =>
+    rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('installs and lists SKILL.md folders', () => {
     installSkill(dir, `---\nname: concise-reports\ndescription: Tight RESULT.md files\n---\nKeep it short.`);
@@ -107,7 +113,9 @@ describe('writeSkillFile', () => {
   beforeEach(() => {
     dir = mkdtempSync(path.join(tmpdir(), 'agentlings-skillfiles-'));
   });
-  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+  afterEach(() =>
+    rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('puts a helper inside the skill, making folders as needed', () => {
     const written = writeSkillFile(dir, 'pdf', 'scripts/fill.py', 'print("hi")\n');

--- a/server/src/settings.test.ts
+++ b/server/src/settings.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -89,7 +90,10 @@ describe('the store on disk', () => {
   beforeEach(() => {
     root = mkdtempSync(path.join(tmpdir(), 'agentlings-settings-'));
   });
-  afterEach(() => rmSync(root, { recursive: true, force: true }));
+  // rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+  afterEach(() =>
+    rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('reads as empty before anything is written, so the catalog decides', () => {
     expect(readSettings(root)).toEqual({});

--- a/server/src/sim.test.ts
+++ b/server/src/sim.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -27,7 +28,10 @@ describe('Sim', () => {
     sim = new Sim(CREW, queue, stuckExecutor);
   });
 
-  afterEach(() => rmSync(root, { recursive: true, force: true }));
+  // rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+  afterEach(() =>
+    rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('patrols in idle: everyone keeps moving and bounces at the walls', () => {
     const before = sim.agentlings.map((a) => a.x);

--- a/server/src/store.test.ts
+++ b/server/src/store.test.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -87,7 +88,10 @@ describe('sync', () => {
   beforeEach(() => {
     root = mkdtempSync(path.join(tmpdir(), 'agentlings-store-'));
   });
-  afterEach(() => rmSync(root, { recursive: true, force: true }));
+  // rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+  afterEach(() =>
+    rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   const write = (rel: string, text: string): void => {
     const full = path.join(root, rel);
@@ -480,7 +484,9 @@ describe('staleness', () => {
   beforeEach(() => {
     dir = mkdtempSync(path.join(tmpdir(), 'agentlings-level-'));
   });
-  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+  afterEach(() =>
+    rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   const indexed = (syncedAt: number): void =>
     writeIndex(dir, {

--- a/server/src/tools.test.ts
+++ b/server/src/tools.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -69,7 +70,10 @@ describe('a tool on disk', () => {
   beforeEach(() => {
     levelDir = mkdtempSync(path.join(tmpdir(), 'agentlings-tools-'));
   });
-  afterEach(() => rmSync(levelDir, { recursive: true, force: true }));
+  // rmSync cannot outwait a Windows file lock — see executors/carry.test.ts.
+  afterEach(() =>
+    rm(levelDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   const complete = (name = 'tidy-invoice') => {
     writeTool(levelDir, manifest({ name }));
@@ -138,7 +142,9 @@ describe('recordToolRun', () => {
     levelDir = mkdtempSync(path.join(tmpdir(), 'agentlings-strikes-'));
     writeTool(levelDir, manifest());
   });
-  afterEach(() => rmSync(levelDir, { recursive: true, force: true }));
+  afterEach(() =>
+    rm(levelDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {}),
+  );
 
   it('counts a clean run and forgets old failures', () => {
     const once = recordToolRun(levelDir, manifest({ failures: 1 }), true);
@@ -181,7 +187,11 @@ describe('promotion', () => {
     beforeEach(() => {
       levelDir = mkdtempSync(path.join(tmpdir(), 'agentlings-names-'));
     });
-    afterEach(() => rmSync(levelDir, { recursive: true, force: true }));
+    afterEach(() =>
+      rm(levelDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(
+        () => {},
+      ),
+    );
 
     it('keeps the plain name while it is free', () => {
       expect(freeToolName(levelDir, 'tidy-invoice')).toBe('tidy-invoice');


### PR DESCRIPTION
`fa4bc37` fixed `carry.test.ts` and deliberately left nineteen other server test
files on the same `rmSync(dir, { recursive: true, force: true })` shape. This
finishes the sweep: **no live `rmSync` remains in any server test file.**

## Why it matters

A vitest hook that throws is reported under the test's own name, so a cleanup
losing a race with a virus scan, OneDrive, or a just-exited `git.exe` is
indistinguishable in the output from a real assertion failure.

The measurement stays in `carry.test.ts` — each file here carries a one-line
pointer to it, not a copy of the account.

## Fault-injected before shipping

On a throwaway copy of `gitwork.test.ts` (the other git-heavy file) whose whole
test body is `expect(1).toBe(1)`, so any failure line can only be the hook. A
PowerShell process holds a file inside the tree at share mode `None`:

```
old rmSync    × lock probe > does its own work ... → EPERM, Permission denied
new async rm  passed; tree actually deleted after 1450ms
```

**The first two probe runs were wrong** and reported the old hook surviving in
10ms. `detached: true` with `stdio: 'ignore'` meant PowerShell never opened the
handle, so nothing was ever locked — the check was scaffolding agreeing with
itself. The probe now blocks on a sentinel the lock-holder writes only after
the handle is open, and refuses to measure until it appears.

## Two sites needed more than the standard shape

- `routed.test.ts` deletes two trees, so its hook awaits both.
- `levels.test.ts:45` is an `rmSync` in a `try/finally` inside a synchronous
  test body. Sharper edge than a hook: `finally` runs *after* the assertions
  have thrown, so an EPERM there **overwrites a real failure** rather than
  inventing one. Converting it made the test `async`, which risks a test that
  can no longer fail — checked by mutation, not by reading:
  `toHaveLength(4) → 5` still reported
  `AssertionError: expected [ …(4) ] to have a length of 5 but got 4`.

## Scope

This removes a demonstrated false-failure mode rather than a caught one — same
standing as `fa4bc37`. It masks nothing: a genuine assertion or git failure
still fails. Source files (`ocr.ts`, `refine.ts`, `documents.ts`, `index.ts`,
`gitwork.ts`, `executors/routed.ts`) also use `rmSync` and are untouched.

## Evidence

```
Test Files  41 passed (41)      Tests  824 passed (824)     [server]
Test Files   7 passed (7)       Tests   74 passed  (74)     [web]
typecheck: shared, server, web — clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
