### PR TITLE
D-162: the moves door measured - sync replay needs no claim, the discard-mid-send window closed, recordMoves dedups

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -171,6 +171,7 @@ decision plus what proved it — length is whatever the evidence takes.
 - [D-159 — 2026-08-11 — The outbox carries files: telegram documents, gmail multipart, review holds the door](#d-159--2026-08-11--the-outbox-carries-files-telegram-documents-gmail-multipart-review-holds-the-door)
 - [D-160 — 2026-08-11 — One door for the outbox send: the double-send race closed at its seam](#d-160--2026-08-11--one-door-for-the-outbox-send-the-double-send-race-closed-at-its-seam)
 - [D-161 — 2026-08-11 — The byte nobody could see: opKey's NUL spelled out, one definition, display split from identity](#d-161--2026-08-11--the-byte-nobody-could-see-opkeys-nul-spelled-out-one-definition-display-split-from-identity)
+- [D-162 — 2026-08-11 — The flagged race, measured: node is the moves door, and the real window was a discard mid-send](#d-162--2026-08-11--the-flagged-race-measured-node-is-the-moves-door-and-the-real-window-was-a-discard-mid-send)
 
 ## By theme
 
@@ -286,7 +287,10 @@ entry updates one file rather than two.
   and D-161, the replay's op identity — the tree's one raw NUL byte (U+0000)
   spelled out as a visible escape, the web copy's space collision closed by
   one shared opKey, and display split from identity so the byte never
-  reaches the review pane
+  reaches the review pane; and D-162, D-160's moves flag measured — the
+  sync replay needs no claim because nothing in it yields, the real window
+  was a discard landing mid-outbox-send, closed by a recheck after the
+  route's one await, with recordMoves dedup mirroring the outbox stamp
 - **Cost** — quotes, ceilings, turn budgets, rates, billing: D-012, D-016–D-018,
   D-026–D-027, D-029; D-130, where a role may raise its own ceiling above the
   global runaway clamp for its class alone (the researcher, measured bound on
@@ -10094,3 +10098,58 @@ this worktree had no `node_modules`, so tsc and vitest resolved
 shared edit was invisible to its own gate — first typecheck failed
 honestly, and `npm install` in the worktree (22s) was the fix. A shared
 edit from a worktree needs the local install first.
+
+## D-162 — 2026-08-11 — The flagged race, measured: node is the moves door, and the real window was a discard mid-send
+
+D-160 flagged the moves replay as its own open race — "the same
+read→act→stamp shape and `recordMoves` the same concatenation merge" —
+and left it for its own decision. Measured before building: the shape
+alone is not the mechanism. The outbox raced because a real send *awaits*
+mid-sequence and a second Approve entered through the yield. The moves
+block has no yield: `executeMoves` is `renameSync` all the way down, the
+journal append and the stamp are synchronous, and `queue.get()` hands out
+the live Map object, not a copy. Two Approves on a moves job therefore
+run strictly one after the other, and the second reads the first's stamp
+in the same event-loop turn and skips every op. The claim D-160 had to
+build for the outbox, the event loop grants this block for free — so no
+claim was added, and the invariant is named in the block's comment
+instead, because an `await` introduced into that stretch would repeal it
+silently. Promote-vs-promote on an outbox-carrying job is likewise
+already refused before the moves block by the send's own claim.
+
+**The window that is real: a discard landing mid-send.** The route's one
+await is the outbox send, `promotable` is computed before it and trusted
+after it, and a *discard* never touches the outbox claim — its path is
+fully synchronous. So a discard arriving while a promote sat parked in a
+multi-second send stamped the verdict, and the resumed promote would
+then have reorganized the real folder, applied the patch and installed
+the pack for a job the user had just discarded — `resolve()` at the tail
+throws on a resolved job (queue.test.ts pins it), but only after every
+side effect had already happened. Closed at the seam: after the outbox
+block, the route re-reads the live status and answers 409 — "while the
+outbox was sending, this job was discarded by another request — nothing
+further was applied". The finished sends stay stamped, because they
+happened and the stamp is the record of that.
+
+**The stamp made a set.** `recordMoves` now dedups `done` by `opKey`
+before accumulating — D-161's one identity, load-bearing at a third seam
+within the same evening. `done` records *what is moved*, not how many
+times moving happened: `reverseMoves` walks it backwards, and a
+duplicated op would fail its second reverse. The same set rule
+`recordOutboxSends` adopted in D-160 for who-was-sent-to.
+
+### What proved it
+
+The measurement: the route read end to end for its awaits (one — the
+send), `get()` returning `this.jobs.get(id)` live, `resolve()` throwing
+on a resolved job already pinned. `recordMoves`'s first-ever test (the
+accumulator had none): accumulate across Approves, never the same op
+twice. Suite green at 1,562 + 184, typecheck clean. One mutation after
+committing (`451e3c6`), one kill: the dedup reverted fails its test; the
+409 recheck is straight-line route code, review-verified, its backstop
+being the pinned resolve() throw. The first mutation attempt refused
+itself — a literal-newline pattern against the CRLF working tree matched
+nothing and the assert-before-write exit stopped a wrong mutation from
+reading as a kill, the dev-lessons rule holding on its second live test
+of the night. Boundary kept honest: the recheck, like D-160's claim, is
+process-local — both racers live in the one server.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1937,6 +1937,23 @@ app.post('/api/levels/:lid/jobs/:id/resolve', async (c) => {
     }
   }
   /**
+   * The send above is this route's one await. If another request resolved the
+   * job while it ran — a discard racing a promote through that window; a
+   * second promote is already refused by the send's own claim — everything
+   * below would reorganize a real folder, apply a patch and install a pack
+   * for a verdict that no longer stands. The finished sends are stamped and
+   * safe; stop here, before anything else real. resolve() at the tail would
+   * throw anyway, but only after those side effects had happened (D-162).
+   */
+  if (promotable && (pending.status === 'promoted' || pending.status === 'discarded')) {
+    return c.json(
+      {
+        error: `while the outbox was sending, this job was ${pending.status} by another request — nothing further was applied`,
+      },
+      409,
+    );
+  }
+  /**
    * A reviewed pack is installed exactly as a reviewed outbox is sent and a
    * reviewed patch applied: at Approve, by us, never by the session (M4).
    *
@@ -2005,6 +2022,12 @@ app.post('/api/levels/:lid/jobs/:id/resolve', async (c) => {
    * a retry skips what already moved. A partial failure returns 400 with the
    * job reviewable, so "Approve again" finishes the rest and moves nothing
    * twice. This is the one branch that touches a real folder outside the app.
+   *
+   * Deliberately synchronous end to end: with the recheck above, nothing
+   * yields between reading `movesRun.done` and stamping it, so two Approves
+   * cannot interleave here — the property D-160 had to build a claim to get
+   * for the outbox, the event loop grants this block for free, and an await
+   * introduced into this stretch would silently take it away (D-162).
    */
   let movedNow = 0;
   if (

--- a/server/src/queue.test.ts
+++ b/server/src/queue.test.ts
@@ -4,6 +4,7 @@ import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { MoveOp } from '@agentlings/shared';
 import { SimulatedExecutor } from './executors/simulated';
 import { OUTBOX_FILE } from './outbox';
 import { deliveredFiles, describeOutputs, producedArtefacts } from './outputs';
@@ -740,6 +741,23 @@ describe('JobQueue', () => {
       queue.start(job.id);
       queue.fail(job.id, 'session timed out');
       expect(queue.get(job.id)!.changes).toBeUndefined();
+    });
+  });
+
+  describe('recordMoves — the accumulator the undo walks back (D-162)', () => {
+    const mk: MoveOp = { op: 'mkdir', path: 'docs' };
+    const mv: MoveOp = { op: 'move', from: 'a b.pdf', to: 'docs/a b.pdf' };
+
+    it('accumulates across Approves and never records the same op twice', () => {
+      const job = queue.add({ title: 'Organize', prompt: 'tidy the folder' });
+      queue.recordMoves(job.id, { done: [mk, mv], failed: [] });
+      // A replay re-reporting a done op must not double it: `done` is what is
+      // moved, and reverseMoves walks it backwards — the second copy would
+      // fail its reverse. Same set rule as the outbox stamp (D-160).
+      const later: MoveOp = { op: 'move', from: 'c.txt', to: 'docs/c.txt' };
+      const after = queue.recordMoves(job.id, { done: [mv, later], failed: [] });
+      expect(after.movesRun?.done).toEqual([mk, mv, later]);
+      expect(after.movesRun?.failed).toEqual([]);
     });
   });
 });

--- a/server/src/queue.ts
+++ b/server/src/queue.ts
@@ -9,7 +9,7 @@ import {
 } from 'node:fs';
 import path from 'node:path';
 import type { Job, JobAttachment, JobMeter, MoveOp } from '@agentlings/shared';
-import { MAX_STATIONS } from '@agentlings/shared';
+import { MAX_STATIONS, opKey } from '@agentlings/shared';
 import { CANCELLED, parsePending } from './executors/claude';
 import { patchFile, summarizePatch, writeDiff } from './gitwork';
 import { readOutbox } from './outbox';
@@ -543,7 +543,13 @@ export class JobQueue {
   recordMoves(jobId: string, run: MovesRunResult): Job {
     const job = this.mustGet(jobId);
     const prior = job.movesRun?.done ?? [];
-    job.movesRun = { at: Date.now(), done: [...prior, ...run.done], failed: run.failed };
+    // `done` records what is moved, not how many times moving happened — the
+    // undo walks it backwards and a duplicated op would fail its second
+    // reverse. The same set rule recordOutboxSends keeps for its stamp
+    // (D-160; D-162).
+    const seen = new Set(prior.map(opKey));
+    const fresh = run.done.filter((op) => !seen.has(opKey(op)));
+    job.movesRun = { at: Date.now(), done: [...prior, ...fresh], failed: run.failed };
     this.persist();
     return job;
   }


### PR DESCRIPTION
## D-162: the flagged race, measured

D-160 flagged the moves replay as its own open race by shape (read → act → stamp). Measured before building: the shape alone is not the mechanism — the outbox raced because a send *awaits* mid-sequence, and the moves block never yields (`renameSync` all the way down, sync journal, sync stamp, `queue.get()` returning live references). Two Approves on a moves job strictly serialize; the second reads the first's stamp in the same event-loop turn and skips every op. **No claim added** — the invariant is named in the block's comment instead, because an `await` introduced into that stretch would repeal it silently.

### The window that is real

The route's one await is the outbox send. `promotable` is computed before it and trusted after it, and a **discard never touches the outbox claim** — so a discard landing while a promote sat parked in a multi-second send stamped the verdict, and the resumed promote would then have reorganized the real folder, applied the patch and installed the pack for a job the user had just discarded, failing only at the tail `resolve()` (which throws — pinned in queue.test.ts) *after* the side effects. Closed with a status recheck after the outbox block: 409, "while the outbox was sending, this job was discarded by another request — nothing further was applied". Finished sends stay stamped — they happened.

### The stamp made a set

`recordMoves` dedups `done` by `opKey` (D-161's one identity, now load-bearing at a third seam): `done` records *what is moved*, and `reverseMoves` walks it backwards — a duplicate would fail its second reverse. Mirrors D-160's `recordOutboxSends` set rule. First-ever test for the accumulator included.

### Proof

Suite 1,562 + 184 green, typecheck clean. One mutation after committing, one kill (dedup reverted → its test fails); the 409 recheck is straight-line route code, review-verified, backstopped by the pinned `resolve()` throw. Full narrative in `DECISIONS.md` D-162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
