### PR TITLE
D-163: the patch-apply claim - the resolve route's second await gets its door

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -172,6 +172,7 @@ decision plus what proved it — length is whatever the evidence takes.
 - [D-160 — 2026-08-11 — One door for the outbox send: the double-send race closed at its seam](#d-160--2026-08-11--one-door-for-the-outbox-send-the-double-send-race-closed-at-its-seam)
 - [D-161 — 2026-08-11 — The byte nobody could see: opKey's NUL spelled out, one definition, display split from identity](#d-161--2026-08-11--the-byte-nobody-could-see-opkeys-nul-spelled-out-one-definition-display-split-from-identity)
 - [D-162 — 2026-08-11 — The flagged race, measured: node is the moves door, and the real window was a discard mid-send](#d-162--2026-08-11--the-flagged-race-measured-node-is-the-moves-door-and-the-real-window-was-a-discard-mid-send)
+- [D-163 — 2026-08-11 — The parallel settlement reconciled: the second await gets its door, D-162's miscount corrected](#d-163--2026-08-11--the-parallel-settlement-reconciled-the-second-await-gets-its-door-d-162s-miscount-corrected)
 
 ## By theme
 
@@ -290,7 +291,11 @@ entry updates one file rather than two.
   reaches the review pane; and D-162, D-160's moves flag measured — the
   sync replay needs no claim because nothing in it yields, the real window
   was a discard landing mid-outbox-send, closed by a recheck after the
-  route's one await, with recordMoves dedup mirroring the outbox stamp
+  route's one await, with recordMoves dedup mirroring the outbox stamp;
+  and D-163, the parallel chip session's verdict reconciled — its moves
+  door declined (both inspections refuted the mechanism), its applyPatch
+  flag adopted as the route's second await getting its own claim, and
+  D-162's one-await sentence corrected by it
 - **Cost** — quotes, ceilings, turn budgets, rates, billing: D-012, D-016–D-018,
   D-026–D-027, D-029; D-130, where a role may raise its own ceiling above the
   global runaway clamp for its class alone (the researcher, measured bound on
@@ -10153,3 +10158,61 @@ nothing and the assert-before-write exit stopped a wrong mutation from
 reading as a kill, the dev-lessons rule holding on its second live test
 of the night. Boundary kept honest: the recheck, like D-160's claim, is
 process-local — both racers live in the one server.
+
+## D-163 — 2026-08-11 — The parallel settlement reconciled: the second await gets its door, D-162's miscount corrected
+
+A routine "anything pending" audit found a second session had worked
+D-160's moves flag in parallel all evening: the chip D-160 spawned, in
+its own worktree, two commits pushed and unmerged, no PR. Its inspection
+reached the same refutation D-162 measured — the moves middle never
+yields, the queue hands out live references, node cannot interleave two
+Approves inside the window — and then settled the opposite way: it built
+`performMovesReplay`/`performMovesUndo` one-door claims anyway, arguing
+the synchrony is "an accident that happens to hold" — a guarantee stated
+nowhere, likeliest in the repo to stop being true (two hundred renames on
+a OneDrive-synced folder; any future awaited progress event) — with
+slowed-executor tests making the unreachable window real, four mutation
+kills. On its way it found the NUL in `opKey` independently (flagged,
+which became D-161's task) and made the identical `recordMoves` dedup
+D-162 merged — three findings converging from two blind sessions. Its
+entry took the number D-161, which main already owns for the opKey
+settlement, so its work is recorded here rather than renumber-merged,
+and its branch closes unmerged once its session is confirmed done.
+
+**Adopted: the applyPatch flag, which caught D-162 in a false claim.**
+D-162's entry and comment say the route has *one* await. It has two —
+the parallel entry lists them precisely — and `await applyPatch` sits
+after the moves block, past D-162's recheck. Inside that second window a
+second promote races `git apply` against the real repository, and a
+discard disowns a patch already going in: side effects for a dead
+verdict, the exact class D-162 closed one await too early. Now claimed
+at the seam, D-160's idiom: `beginPatch`/`endPatch`/`patchInFlight`
+beside `applyPatch` in gitwork.ts, the resolve route's door refusing
+*both* actions 409 while a job's patch is in flight ("the first Approve
+is doing it"), the apply block releasing in a `finally` so a failed
+apply leaves the job retryable. The door check is the refusal; the flag
+exists so the door can see across the await.
+
+**Declined: the moves door.** Both inspections agree the mechanism is
+unreachable, and D-162's settlement — synchrony named as a load-bearing
+comment rather than armored by construction — was decided the same
+evening and stands. The fragility argument is real and is now carried by
+two independent records plus the comment in the block; if the moves
+middle ever grows an await, this pair of entries is the alarm that says
+which door to build and how it was already built once.
+
+### What proved it
+
+Three claim tests appended to gitwork's existing suite; full suite green
+at 1,565 + 184 — the arithmetic closing exactly (1,562 + 3) — and
+typecheck clean. Two mutations after committing (`e61fda5`), two kills:
+`beginPatch` made a no-op fails the holds-between test; `endPatch` made
+a no-op fails two, the leaked claim poisoning what follows, D-160's
+pattern again. And one process catch worth its sentence: the first
+version of the tests was Written as a "new" gitwork.test.ts on a false
+recollection that none existed — clobbering the tracked suite M1 shipped
+(four tests, including applyPatch's own round trip), with the read-first
+guard not firing in the fresh worktree. The tell was the suite counting
+*down* while green: 66 files and 1,561 where 1,565 was owed. Restored
+from HEAD, the claim tests appended instead. A green suite that got
+smaller is a red flag with a number on it.

--- a/server/src/gitwork.test.ts
+++ b/server/src/gitwork.test.ts
@@ -4,7 +4,16 @@ import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { applyPatch, cloneRepo, patchFile, summarizePatch, writeDiff } from './gitwork';
+import {
+  applyPatch,
+  beginPatch,
+  cloneRepo,
+  endPatch,
+  patchFile,
+  patchInFlight,
+  summarizePatch,
+  writeDiff,
+} from './gitwork';
 
 function git(cwd: string, ...args: string[]): void {
   execFileSync('git', ['-C', cwd, ...args], { stdio: 'pipe' });
@@ -75,5 +84,28 @@ describe('gitwork', () => {
 
   it('refuses to apply a missing patch', async () => {
     await expect(applyPatch(origin, patchFile(sandbox))).rejects.toThrow(/no DIFF.patch/);
+  });
+});
+
+describe('the patch-apply claim (D-163)', () => {
+  it('holds exactly between begin and end — the resolve door reads it', () => {
+    expect(patchInFlight('j1')).toBe(false);
+    beginPatch('j1');
+    expect(patchInFlight('j1')).toBe(true);
+    endPatch('j1');
+    expect(patchInFlight('j1')).toBe(false);
+  });
+
+  it('is per job — one job mid-patch never blocks another', () => {
+    beginPatch('j2');
+    expect(patchInFlight('j3')).toBe(false);
+    endPatch('j2');
+  });
+
+  it('releasing twice is safe — a finally can never throw or leak', () => {
+    beginPatch('j4');
+    endPatch('j4');
+    endPatch('j4');
+    expect(patchInFlight('j4')).toBe(false);
   });
 });

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -72,3 +72,28 @@ export async function applyPatch(targetRepoPath: string, patch: string): Promise
   if (!existsSync(patch)) throw new Error('no DIFF.patch to apply');
   await run('git', ['-C', targetRepoPath, 'apply', '--whitespace=nowarn', patch]);
 }
+
+/**
+ * The patch-apply claim (D-163). `applyPatch` is the resolve route's second
+ * await — D-162's recheck guards the first — and a resolve request landing
+ * inside it would either race a second `git apply` onto the real repository
+ * or discard a job whose patch is mid-flight. The route's door refuses both
+ * actions while a job is claimed; the apply block releases in a `finally`,
+ * so a failed apply leaves the job resolvable. Process-local like D-160's
+ * send claim, which is the scope of the race: every caller lives in this
+ * one server.
+ */
+const patching = new Set<string>();
+
+/** Marks the job's patch mid-flight. The route's door is what refuses on it. */
+export function beginPatch(jobId: string): void {
+  patching.add(jobId);
+}
+
+export function endPatch(jobId: string): void {
+  patching.delete(jobId);
+}
+
+export function patchInFlight(jobId: string): boolean {
+  return patching.has(jobId);
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -94,7 +94,7 @@ import { RoutedExecutor } from './executors/routed';
 import { SimulatedExecutor } from './executors/simulated';
 import { categorise, entriesIn, indexedBySource } from './browse';
 import { deliveredIds, DELIVERIES_SHOWN, deliveriesFor } from './deliveries';
-import { applyPatch, patchFile } from './gitwork';
+import { applyPatch, beginPatch, endPatch, patchFile, patchInFlight } from './gitwork';
 import {
   appendKnowledge,
   createLevelFiles,
@@ -1836,6 +1836,18 @@ app.post('/api/levels/:lid/jobs/:id/resolve', async (c) => {
   }
   const pending = rt.queue.get(c.req.param('id'));
   if (!pending) return c.json({ error: 'unknown job' }, 404);
+  // A resolve must never land inside this job's own patch-apply await
+  // (D-163): a second promote would race `git apply` on the real
+  // repository, and a discard would disown a patch already going in.
+  if (patchInFlight(pending.id)) {
+    return c.json(
+      {
+        error:
+          "this job's patch is still applying — the first Approve is doing it; try again when it lands",
+      },
+      409,
+    );
+  }
   // Promote replays the reviewed patch onto the real repository first;
   // the job is only marked promoted if the patch applies cleanly.
   //
@@ -1937,7 +1949,8 @@ app.post('/api/levels/:lid/jobs/:id/resolve', async (c) => {
     }
   }
   /**
-   * The send above is this route's one await. If another request resolved the
+   * The send above is the first of this route's two awaits — the patch apply
+   * below is the second, claimed at the door (D-163). If another request resolved the
    * job while it ran — a discard racing a promote through that window; a
    * second promote is already refused by the send's own claim — everything
    * below would reorganize a real folder, apply a patch and install a pack
@@ -2069,11 +2082,14 @@ app.post('/api/levels/:lid/jobs/:id/resolve', async (c) => {
   if (body.action === 'promote' && promotable && pending.repoPath && !waitingTool) {
     const patch = patchFile(rt.queue.sandboxDir(pending.id));
     if (existsSync(patch)) {
+      beginPatch(pending.id);
       try {
         await applyPatch(pending.repoPath, patch);
       } catch (err) {
         const detail = err instanceof Error ? err.message : String(err);
         return c.json({ error: `patch did not apply: ${detail}` }, 400);
+      } finally {
+        endPatch(pending.id);
       }
     }
   }


### PR DESCRIPTION
## D-163: the parallel settlement reconciled

An "anything pending" audit found the chip session D-160 spawned had worked the same moves flag in parallel — two commits pushed on `claude/eager-germain-7f0208`, unmerged, no PR. Its inspection reached the **same refutation** as merged D-162 (the moves middle never yields; node serializes it) and settled the opposite way: it built the claim door anyway as armor. It also found the `opKey` NUL independently (which became D-161's task) and converged on the identical `recordMoves` dedup — three findings from two blind sessions.

### Adopted: its `applyPatch` flag — which caught D-162 in a false claim

D-162 wrote "this route's **one** await." There are two: `await applyPatch` sits *past* D-162's recheck. Inside that second window, a second promote races `git apply` against the real repository, and a discard disowns a patch already going in. Now claimed at the seam in D-160's idiom: `beginPatch`/`endPatch`/`patchInFlight` beside `applyPatch`, the resolve route's door refusing **both actions** with 409 while a job's patch is in flight, released in a `finally` so a failed apply stays retryable. D-162's comment corrected in place.

### Declined: its moves door

Both inspections agree that mechanism is unreachable; D-162's same-evening settlement stands. The fragility argument now lives in two independent records plus the load-bearing comment — the alarm if that stretch ever grows an await. The parallel entry numbered itself D-161 (already owned on main by the opKey settlement), so its work is recorded in D-163 rather than renumber-merged; its branch closes unmerged once its session is confirmed done.

### Proof

Suite **1,565 + 184** green (arithmetic exact: 1,562 + 3 new claim tests, appended to gitwork's *existing* suite), typecheck clean. Two mutations, two kills (`beginPatch` no-op; `endPatch` no-op leaking the claim into two failures). Also owned in the entry: the first test version clobbered the tracked gitwork suite on a false "no such file" recollection — caught because the green suite counted *down* (1,561 where 1,565 was owed), restored from HEAD, appended instead.

Full narrative in `DECISIONS.md` D-163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
